### PR TITLE
Constrain text element widths and improve multiselect layout

### DIFF
--- a/crates/popup-gui/src/gui/mod.rs
+++ b/crates/popup-gui/src/gui/mod.rs
@@ -8,19 +8,6 @@ use crate::theme::Theme;
 use popup_common::{evaluate_condition, parse_condition};
 use popup_common::{Element, PopupDefinition, PopupResult, PopupState};
 
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    pub fn collect_active_elements_for_test(
-        elements: &[Element],
-        state: &PopupState,
-        all_elements: &[Element],
-    ) -> Vec<String> {
-        super::collect_active_elements(elements, state, all_elements, "")
-    }
-}
-
 fn setup_custom_fonts(ctx: &Context) {
     // Install image loaders for egui-twemoji (required for emoji rendering)
     egui_extras::install_image_loaders(ctx);
@@ -274,8 +261,6 @@ impl eframe::App for PopupApp {
         }
     }
 }
-
-// Removed old rendering functions that are no longer used
 
 struct RenderContext<'a> {
     theme: &'a Theme,
@@ -1031,4 +1016,15 @@ fn collect_active_elements(
     active_ids
 }
 
+#[cfg(test)]
+pub mod tests {
+    use super::*;
 
+    pub fn collect_active_elements_for_test(
+        elements: &[Element],
+        state: &PopupState,
+        all_elements: &[Element],
+    ) -> Vec<String> {
+        super::collect_active_elements(elements, state, all_elements, "")
+    }
+}


### PR DESCRIPTION
## Summary
- Text/markdown elements constrained to max 400px width
- Input elements constrained to max 400px (previously expanded to full available width)
- Multiselect now uses true 2-column layout (was incorrectly 3 columns) with 250px cell width and text wrapping for long labels
- Fixed deprecated `Frame::none()` → `Frame::NONE`

## Test plan
- [x] All 50 unit tests passing
- [ ] Manual verification of narrower text boxes in popup UI
- [ ] Manual verification of multiselect 2-column layout with wrapped labels

🤖 Generated with [Claude Code](https://claude.ai/claude-code)